### PR TITLE
Improve debug and modbus config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Firmware replacement for Growatt ShineWiFi-S (serial), ShineWiFi-X (USB) or cust
     * For the original Arduino IDE follow the instruction in the main ino [file](https://github.com/otti/Growatt_ShineWiFi-S/blob/master/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino)
     * For platformio just open the project folder and choose the correct env for your hardware
 * Rename and adapt [Config.h.example](https://github.com/otti/Growatt_ShineWiFi-S/blob/master/SRC/ShineWiFi-ModBus/Config.h.example) to Config.h with your compile time settings
+* To access the `/debug` and `/postCommunicationModbus` pages, ensure that `ENABLE_WEB_DEBUG` and `ENABLE_MODBUS_COMMUNICATION` are set in `Config.h`
 * Flash to an esp32/esp8266
 * For detailed flashing instructions see https://github.com/otti/Growatt_ShineWiFi-S/blob/master/Doc/
 * Connect to the setup wifi called GrowattConfig (PW: growsolar) and configure the firmware via the webinterface at http://192.168.4.1

--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -30,7 +30,8 @@
 #define ENABLE_DEBUG_OUTPUT 1
 
 // Setting this define to 1 will enable a web page (<ip>/debug) where debug messages can be displayed
-#define ENABLE_WEB_DEBUG 0
+// Enabling this option is useful for troubleshooting
+#define ENABLE_WEB_DEBUG 1
 
 // Setting this flag to 1 will simulate the inverter
 // This could be helpful if it is night and the inverter is not working or

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -35,6 +35,15 @@ e.g. C:\Users\<username>\AppData\Local\Temp\arduino_build_533155
 #error Please rename config.h.example to config.h
 #endif
 
+// Provide sensible defaults if the compile-time flags are not set
+#ifndef ENABLE_MODBUS_COMMUNICATION
+#define ENABLE_MODBUS_COMMUNICATION 1
+#endif
+
+#ifndef ENABLE_WEB_DEBUG
+#define ENABLE_WEB_DEBUG 0
+#endif
+
 
 
 #ifdef ESP8266


### PR DESCRIPTION
## Summary
- enable web debug in the example configuration
- provide default definitions for `ENABLE_MODBUS_COMMUNICATION` and `ENABLE_WEB_DEBUG`
- document how to enable `/debug` and `/postCommunicationModbus`

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b9634664c832a8b68c15dc3db7ad0