### PR TITLE
Add Fronius API emulation endpoint

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -24,6 +24,7 @@ class Growatt {
     bool WriteHoldingReg(uint16_t adr, uint16_t value);
     void CreateJson(char *Buffer, const char *MacAddress);
     void CreateUIJson(char *Buffer);
+    void CreateFroniusJson(char *Buffer);
   private:
     eDevice_t _eDevice;
     bool _GotData;

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -575,6 +575,7 @@ void setup()
 
     httpServer.on("/status", SendJsonSite);
     httpServer.on("/uistatus", SendUiJsonSite);
+    httpServer.on("/solar_api/v1/GetInverterRealtimeData.cgi", SendFroniusSite);
     httpServer.on("/StartAp", StartConfigAccessPoint);
     httpServer.on("/postCommunicationModbus", SendPostSite);
     httpServer.on("/postCommunicationModbus_p", HTTP_POST, handlePostData);
@@ -601,6 +602,13 @@ void SendUiJsonSite(void)
 {
     JsonString[0] = '\0';
     Inverter.CreateUIJson(JsonString);
+    httpServer.send(200, "application/json", JsonString);
+}
+
+void SendFroniusSite(void)
+{
+    JsonString[0] = '\0';
+    Inverter.CreateFroniusJson(JsonString);
     httpServer.send(200, "application/json", JsonString);
 }
 


### PR DESCRIPTION
## Summary
- expose Fronius compatible data at `/solar_api/v1/GetInverterRealtimeData.cgi`
- generate JSON output in Fronius Solar API style

## Testing
- `g++ -std=c++11 -fsyntax-only SRC/ShineWiFi-ModBus/Growatt.cpp` *(fails: ModbusMaster.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6860c73dda68832aa3f0dc9fa932c28f