### PR TITLE
Add NTP timestamp for Fronius JSON

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -8,6 +8,7 @@
 #ifndef __CONFIG_H__
 #error Please rename Config.h.example to Config.h
 #endif
+#include <time.h>
 
 #if GROWATT_MODBUS_VERSION == 120
   #include "Growatt120.h"
@@ -385,7 +386,13 @@ void Growatt::CreateFroniusJson(char *Buffer) {
   status["Code"] = 0;
   status["Reason"] = "";
   status["UserMessage"] = "";
-  head["Timestamp"] = (uint32_t)millis() / 1000;
+  time_t now = time(nullptr);
+  struct tm *tm_info = localtime(&now);
+  char ts[30];
+  snprintf(ts, sizeof(ts), "%04d-%02d-%02dT%02d:%02d:%02d+00:00",
+           tm_info->tm_year + 1900, tm_info->tm_mon + 1, tm_info->tm_mday,
+           tm_info->tm_hour, tm_info->tm_min, tm_info->tm_sec);
+  head["Timestamp"] = ts;
 
   JsonObject body = doc.createNestedObject("Body");
   JsonObject data = body.createNestedObject("Data");

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -110,6 +110,7 @@ bool StartedConfigAfterBoot = false;
 #include <Pinger.h>
 #include <PingerResponse.h>
 #endif
+#include <time.h>
 
 #define LED_GN 0  // GPIO0
 #define LED_RT 2  // GPIO2
@@ -553,6 +554,14 @@ void setup()
     while (WiFi.status() != WL_CONNECTED)
     {
         WiFi_Reconnect();
+    }
+
+    // Initialize time via NTP for proper timestamp generation
+    configTime(0, 0, "pool.ntp.org");
+    time_t now = time(nullptr);
+    for (uint8_t i = 0; i < 10 && now < 100000; i++) {
+        delay(500);
+        now = time(nullptr);
     }
 
     #if MQTT_SUPPORTED == 1


### PR DESCRIPTION
## Summary
- include `time.h` and sync time with `pool.ntp.org`
- generate ISO8601 timestamp for Fronius response

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860ccd5ac74832aa962cfd43dacd8bf