### PR TITLE
Add device info endpoint

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -308,6 +308,29 @@ void Growatt::CreateJson(char *Buffer, const char *MacAddress) {
   serializeJson(doc, Buffer, MQTT_MAX_PACKET_SIZE);
 }
 
+void Growatt::CreateDeviceInfoJson(char *Buffer) {
+  StaticJsonDocument<512> doc;
+
+  JsonObject head = doc.createNestedObject("Head");
+  head.createNestedObject("RequestArguments");
+  JsonObject status = head.createNestedObject("Status");
+  status["Code"] = 0;
+  time_t now = time(nullptr);
+  struct tm *tm_info = localtime(&now);
+  char ts[30];
+  snprintf(ts, sizeof(ts), "%04d-%02d-%02dT%02d:%02d:%02d+00:00",
+           tm_info->tm_year + 1900, tm_info->tm_mon + 1, tm_info->tm_mday,
+           tm_info->tm_hour, tm_info->tm_min, tm_info->tm_sec);
+  head["Timestamp"] = ts;
+
+  JsonObject body = doc.createNestedObject("Body");
+  JsonObject data = body.createNestedObject("Data");
+  data["DeviceType"] = 122;
+  data["Serial"] = "GW-GROWATT-EMU";
+
+  serializeJson(doc, Buffer, MQTT_MAX_PACKET_SIZE);
+}
+
 void Growatt::CreateUIJson(char *Buffer) {
   StaticJsonDocument<2048> doc;
   const char* unitStr[] = {"", "W", "kWh", "V", "A", "s", "%", "Hz", "C"};

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -25,6 +25,7 @@ class Growatt {
     void CreateJson(char *Buffer, const char *MacAddress);
     void CreateUIJson(char *Buffer);
     void CreateFroniusJson(char *Buffer);
+    void CreateDeviceInfoJson(char *Buffer);
   private:
     eDevice_t _eDevice;
     bool _GotData;

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -585,6 +585,7 @@ void setup()
     httpServer.on("/status", SendJsonSite);
     httpServer.on("/uistatus", SendUiJsonSite);
     httpServer.on("/solar_api/v1/GetInverterRealtimeData.cgi", SendFroniusSite);
+    httpServer.on("/solar_api/v1/GetDeviceInfo.cgi", SendDeviceInfoSite);
     httpServer.on("/StartAp", StartConfigAccessPoint);
     httpServer.on("/postCommunicationModbus", SendPostSite);
     httpServer.on("/postCommunicationModbus_p", HTTP_POST, handlePostData);
@@ -618,6 +619,13 @@ void SendFroniusSite(void)
 {
     JsonString[0] = '\0';
     Inverter.CreateFroniusJson(JsonString);
+    httpServer.send(200, "application/json", JsonString);
+}
+
+void SendDeviceInfoSite(void)
+{
+    JsonString[0] = '\0';
+    Inverter.CreateDeviceInfoJson(JsonString);
     httpServer.send(200, "application/json", JsonString);
 }
 


### PR DESCRIPTION
## Summary
- implement new DeviceInfo endpoint for the simulator
- expose the endpoint via the HTTP server

## Testing
- `platformio run -e shinewifix_tlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860cfe89f68832a84550f7e34690d80