### PR TITLE
Add missing Fronius endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Implemented Features:
 * It supports convenient OTA firmware update (`http://<ip>/firmware`)
 * It supports basic access to arbitrary modbus data
 * It tries to autodected which protocol version to use
+* Provides a small subset of the Fronius Solar API to ease integration:
+  `/solar_api/v1/GetInverterInfo.cgi`, `/solar_api/v1/GetPowerFlowRealtimeData.fcgi`,
+  `/solar_api/v1/GetLoggerInfo.cgi`, and `/solar_api/v1/GetActiveDeviceInfo.cgi`
 * Wifi manager with own access point for initial configuration of Wifi and MQTT server (IP: 192.168.4.1, SSID: GrowattConfig, Pass: growsolar)
 * Currently Growatt v1.24 and 3.05 protocols are implemented and can be easily extended/changed to fit anyone's needs
 

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -539,3 +539,95 @@ void Growatt::CreatePowerFlowJson(char *Buffer) {
 
   serializeJson(doc, Buffer, MQTT_MAX_PACKET_SIZE);
 }
+
+void Growatt::CreateInverterInfoJson(char *Buffer) {
+  StaticJsonDocument<512> doc;
+
+  JsonObject head = doc.createNestedObject("Head");
+  head.createNestedObject("RequestArguments");
+  JsonObject status = head.createNestedObject("Status");
+  status["Code"] = 0;
+  status["Reason"] = "";
+  status["UserMessage"] = "";
+  time_t now = time(nullptr);
+  struct tm *tm_info = localtime(&now);
+  char ts[30];
+  snprintf(ts, sizeof(ts), "%04d-%02d-%02dT%02d:%02d:%02d+00:00",
+           tm_info->tm_year + 1900, tm_info->tm_mon + 1, tm_info->tm_mday,
+           tm_info->tm_hour, tm_info->tm_min, tm_info->tm_sec);
+  head["Timestamp"] = ts;
+
+  JsonObject body = doc.createNestedObject("Body");
+  JsonObject data = body.createNestedObject("Data");
+  JsonObject inv = data.createNestedObject("1");
+
+#if GROWATT_MODBUS_VERSION == 305
+  double pdc = _Protocol.InputRegisters[P305_DC_POWER].value * _Protocol.InputRegisters[P305_DC_POWER].multiplier * 1000.0;
+#elif GROWATT_MODBUS_VERSION == 120
+  double pdc = _Protocol.InputRegisters[P120_INPUT_POWER].value * _Protocol.InputRegisters[P120_INPUT_POWER].multiplier * 1000.0;
+#elif GROWATT_MODBUS_VERSION == 124
+  double pdc = _Protocol.InputRegisters[P124_INPUT_POWER].value * _Protocol.InputRegisters[P124_INPUT_POWER].multiplier * 1000.0;
+#else
+  double pdc = 0;
+#endif
+
+  inv["CustomName"] = "Growatt Inverter";
+  inv["DT"] = FRONIUS_DEVICE_TYPE;
+  inv["ErrorCode"] = 0;
+  inv["PVPower"] = (uint32_t)pdc;
+  inv["Show"] = 1;
+  inv["StatusCode"] = 7;
+  inv["UniqueID"] = FRONIUS_SERIAL;
+
+  serializeJson(doc, Buffer, MQTT_MAX_PACKET_SIZE);
+}
+
+void Growatt::CreateLoggerInfoJson(char *Buffer) {
+  StaticJsonDocument<512> doc;
+
+  JsonObject head = doc.createNestedObject("Head");
+  head.createNestedObject("RequestArguments");
+  JsonObject status = head.createNestedObject("Status");
+  status["Code"] = 0;
+  status["Reason"] = "";
+  status["UserMessage"] = "";
+  time_t now = time(nullptr);
+  struct tm *tm_info = localtime(&now);
+  char ts[30];
+  snprintf(ts, sizeof(ts), "%04d-%02d-%02dT%02d:%02d:%02d+00:00",
+           tm_info->tm_year + 1900, tm_info->tm_mon + 1, tm_info->tm_mday,
+           tm_info->tm_hour, tm_info->tm_min, tm_info->tm_sec);
+  head["Timestamp"] = ts;
+
+  JsonObject body = doc.createNestedObject("Body");
+  JsonObject data = body.createNestedObject("LoggerInfo");
+  data["SWVersion"] = "1.0";
+  data["HWVersion"] = "1.0";
+  data["TimezoneLocation"] = "UTC";
+
+  serializeJson(doc, Buffer, MQTT_MAX_PACKET_SIZE);
+}
+
+void Growatt::CreateActiveDeviceInfoJson(char *Buffer) {
+  StaticJsonDocument<256> doc;
+
+  JsonObject head = doc.createNestedObject("Head");
+  JsonObject args = head.createNestedObject("RequestArguments");
+  args["DeviceClass"] = "SensorCard";
+  JsonObject status = head.createNestedObject("Status");
+  status["Code"] = 0;
+  status["Reason"] = "";
+  status["UserMessage"] = "";
+  time_t now = time(nullptr);
+  struct tm *tm_info = localtime(&now);
+  char ts[30];
+  snprintf(ts, sizeof(ts), "%04d-%02d-%02dT%02d:%02d:%02d+00:00",
+           tm_info->tm_year + 1900, tm_info->tm_mon + 1, tm_info->tm_mday,
+           tm_info->tm_hour, tm_info->tm_min, tm_info->tm_sec);
+  head["Timestamp"] = ts;
+
+  JsonObject body = doc.createNestedObject("Body");
+  body.createNestedObject("Data");
+
+  serializeJson(doc, Buffer, MQTT_MAX_PACKET_SIZE);
+}

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -27,6 +27,9 @@ class Growatt {
     void CreateFroniusJson(char *Buffer);
     void CreatePowerFlowJson(char *Buffer);
     void CreateDeviceInfoJson(char *Buffer);
+    void CreateInverterInfoJson(char *Buffer);
+    void CreateLoggerInfoJson(char *Buffer);
+    void CreateActiveDeviceInfoJson(char *Buffer);
   private:
     eDevice_t _eDevice;
     bool _GotData;

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -587,6 +587,9 @@ void setup()
     httpServer.on("/solar_api/v1/GetInverterRealtimeData.cgi", SendFroniusSite);
     httpServer.on("/solar_api/v1/GetPowerFlowRealtimeData.fcgi", SendPowerFlowSite);
     httpServer.on("/solar_api/v1/GetDeviceInfo.cgi", SendDeviceInfoSite);
+    httpServer.on("/solar_api/v1/GetInverterInfo.cgi", SendInverterInfoSite);
+    httpServer.on("/solar_api/v1/GetLoggerInfo.cgi", SendLoggerInfoSite);
+    httpServer.on("/solar_api/v1/GetActiveDeviceInfo.cgi", SendActiveDeviceInfoSite);
     httpServer.on("/StartAp", StartConfigAccessPoint);
     httpServer.on("/postCommunicationModbus", SendPostSite);
     httpServer.on("/postCommunicationModbus_p", HTTP_POST, handlePostData);
@@ -634,6 +637,27 @@ void SendDeviceInfoSite(void)
 {
     JsonString[0] = '\0';
     Inverter.CreateDeviceInfoJson(JsonString);
+    httpServer.send(200, "application/json", JsonString);
+}
+
+void SendInverterInfoSite(void)
+{
+    JsonString[0] = '\0';
+    Inverter.CreateInverterInfoJson(JsonString);
+    httpServer.send(200, "application/json", JsonString);
+}
+
+void SendLoggerInfoSite(void)
+{
+    JsonString[0] = '\0';
+    Inverter.CreateLoggerInfoJson(JsonString);
+    httpServer.send(200, "application/json", JsonString);
+}
+
+void SendActiveDeviceInfoSite(void)
+{
+    JsonString[0] = '\0';
+    Inverter.CreateActiveDeviceInfoJson(JsonString);
     httpServer.send(200, "application/json", JsonString);
 }
 

--- a/SRC/ShineWiFi-ModBus/index.h
+++ b/SRC/ShineWiFi-ModBus/index.h
@@ -35,7 +35,10 @@ copies or substantial portions of the Software. -->
   <a href="./StartAp">Start config access point</a> -
   <a href="./postCommunicationModbus">RW Modbus</a> -
   <a href="./solar_api/v1/GetInverterRealtimeData.cgi">Fronius Inverter Data</a> -
+  <a href="./solar_api/v1/GetInverterInfo.cgi">Fronius Inverter Info</a> -
   <a href="./solar_api/v1/GetDeviceInfo.cgi">Fronius Device Info</a> -
+  <a href="./solar_api/v1/GetLoggerInfo.cgi">Fronius Logger Info</a> -
+  <a href="./solar_api/v1/GetActiveDeviceInfo.cgi">Fronius Active Device</a> -
   <a href="./solar_api/v1/GetPowerFlowRealtimeData.fcgi">Fronius Power Flow</a>
 
 </body>


### PR DESCRIPTION
## Summary
- emulate more Fronius endpoints
- hook new handlers for the endpoints
- show links to new API endpoints in the main web UI
- document Fronius API support in the README

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861edabaa98832a8b74d03856a0e4a4