### PR TITLE
Update GitHub cache action

### DIFF
--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -14,14 +14,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Cache PlatformIO
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}


### PR DESCRIPTION
## Summary
- use `actions/cache@v4` for caching pip and PlatformIO dependencies

## Testing
- `pip install platformio` *(fails: Tunnel connection failed)*
- `pio run -e ShineWifiX -e lolin32 -e nodemcu-32s` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861ef4eff3c832ab3574bb428eb8d76