### PR TITLE
Improve Fronius endpoint data

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -30,6 +30,7 @@ class Growatt {
     void CreateInverterInfoJson(char *Buffer);
     void CreateLoggerInfoJson(char *Buffer);
     void CreateActiveDeviceInfoJson(char *Buffer);
+    static uint8_t MapStatusToFronius(uint32_t status);
   private:
     eDevice_t _eDevice;
     bool _GotData;


### PR DESCRIPTION
## Summary
- map Growatt inverter status to Fronius status codes
- expose per phase energy in Fronius `GetInverterRealtimeData` output

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861f4bc7668832a99cb0a928b3a5a3b