### PR TITLE
Fix undefined variable error in Growatt.cpp

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -516,6 +516,17 @@ void Growatt::CreateFroniusJson(char *Buffer) {
     totE_l3 = totE * pac_l3 / sumPac;
   }
 
+#if GROWATT_MODBUS_VERSION == 305
+  uint32_t gwStatus = _Protocol.InputRegisters[P305_I_STATUS].value;
+#elif GROWATT_MODBUS_VERSION == 120
+  uint32_t gwStatus = _Protocol.InputRegisters[P120_I_STATUS].value;
+#elif GROWATT_MODBUS_VERSION == 124
+  uint32_t gwStatus = _Protocol.InputRegisters[P124_I_STATUS].value;
+#else
+  uint32_t gwStatus = 0;
+#endif
+  uint8_t froniusStatus = MapStatusToFronius(gwStatus);
+
   JsonObject pacObj = data.createNestedObject("PAC");
   pacObj["Value"] = pac;
   pacObj["Unit"] = "W";


### PR DESCRIPTION
## Summary
- define `froniusStatus` in `CreateFroniusJson`

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861f8751f9c832a943d11dfe71b6e90