### PR TITLE
Remove tracked Config.h

### DIFF
--- a/copy_config.py
+++ b/copy_config.py
@@ -6,6 +6,7 @@ try:
     Import("env")
     project_dir = env["PROJECT_DIR"]
 except Exception:
+    env = None
     project_dir = os.path.dirname(os.path.abspath(__file__))
 
 config_example = os.path.join(project_dir, 'SRC', 'ShineWiFi-ModBus', 'Config.h.example')
@@ -16,13 +17,26 @@ def running_in_codex() -> bool:
     return any(key.startswith("CODEX_") for key in os.environ)
 
 
+def copy_config() -> None:
+    if os.path.isfile(config_example) and not os.path.isfile(config_target):
+        shutil.copy(config_example, config_target)
+        print('copy_config.py: copied Config.h.example to Config.h')
+
+
+def remove_config(*_args: object, **_kwargs: object) -> None:
+    if os.path.isfile(config_target):
+        os.remove(config_target)
+        print('copy_config.py: removed Config.h')
+
+
 def main() -> None:
     if not running_in_codex():
         return
 
-    if not os.path.isfile(config_target) and os.path.isfile(config_example):
-        shutil.copy(config_example, config_target)
-        print('copy_config.py: copied Config.h.example to Config.h')
+    copy_config()
+
+    if env is not None:
+        env.AddPostAction("buildprog", remove_config)
 
 
 main()

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ lib_ldf_mode = deep+
 platform = espressif8266
 board = esp07s
 framework = arduino
+extra_scripts = pre:copy_config.py
 build_flags =
     ${env.build_flags}
     "-D ENABLE_MODBUS_COMMUNICATION=1"


### PR DESCRIPTION
## Summary
- stop tracking Config.h again
- create and remove Config.h during Codex builds
- call the copy script in the default environment

## Testing
- `platformio run -e shinewifix_tlx`


------
https://chatgpt.com/codex/tasks/task_b_6863466f21c4832ab78f40382b359fe4