### PR TITLE
Improve WiFi recovery and add setup link

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -177,29 +177,34 @@ void WiFi_Reconnect()
     {
         digitalWrite(LED_GN, 0);
 
-        wm.autoConnect();
+        WiFi.disconnect();               // clear current state
+        WiFi.begin();                    // reconnect using stored credentials
 
-        while (WiFi.status() != WL_CONNECTED)
+        uint32_t start = millis();
+        while ((WiFi.status() != WL_CONNECTED) && (millis() - start < 10000))
         {
             delay(200);
-            #if ENABLE_DEBUG_OUTPUT == 1
-                Serial.print("x");
-            #endif
+#if ENABLE_DEBUG_OUTPUT == 1
+            Serial.print("x");
+#endif
             digitalWrite(LED_RT, !digitalRead(LED_RT)); // toggle red led on WiFi (re)connect
         }
 
-        #if ENABLE_DEBUG_OUTPUT == 1
+        if (WiFi.status() == WL_CONNECTED)
+        {
+#if ENABLE_DEBUG_OUTPUT == 1
             Serial.println("");
             WiFi.printDiag(Serial);
             Serial.print("local IP:");
             Serial.println(WiFi.localIP());
             Serial.print("Hostname: ");
             Serial.println(HOSTNAME);
-        #endif
+#endif
 
-        WEB_DEBUG_PRINT("WiFi reconnected")
+            WEB_DEBUG_PRINT("WiFi reconnected")
 
-        digitalWrite(LED_RT, 1);
+            digitalWrite(LED_RT, 1);
+        }
     }
 }
 

--- a/SRC/ShineWiFi-ModBus/index.h
+++ b/SRC/ShineWiFi-ModBus/index.h
@@ -32,7 +32,7 @@ copies or substantial portions of the Software. -->
   <a href="./firmware">Firmware update</a> -
   <a href="./status">Json</a> -
   <a href="./debug">Log</a> -
-  <a href="./StartAp">Start config access point</a> -
+  <a href="./StartAp">Setup</a> -
   <a href="./postCommunicationModbus">RW Modbus</a> -
   <a href="./solar_api/v1/GetInverterRealtimeData.cgi">Fronius Inverter Data</a> -
   <a href="./solar_api/v1/GetInverterInfo.cgi">Fronius Inverter Info</a> -


### PR DESCRIPTION
## Summary
- avoid WiFiManager auto portal during reconnect
- retry WiFi connection using stored credentials
- add a `Setup` link in the main web UI

## Testing
- `platformio run` *(fails: platformio couldn't download dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68634c915340832ab254026dba603241