### PR TITLE
Increase UI JSON buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Implemented Features:
   `/solar_api/v1/GetInverterInfo.cgi`, `/solar_api/v1/GetPowerFlowRealtimeData.fcgi`,
   `/solar_api/v1/GetLoggerInfo.cgi`, and `/solar_api/v1/GetActiveDeviceInfo.cgi`
 * AC phase statistics (L1-L3) are exposed through the Fronius API endpoints
+* Fronius API responses include a textual Status field derived from Growatt status
 * Wifi manager with own access point for initial configuration of Wifi and MQTT server (IP: 192.168.4.1, SSID: GrowattConfig, Pass: growsolar)
 * Currently Growatt v1.24, v1.25 and 3.05 protocols are implemented and can be easily extended/changed to fit anyone's needs
 * Protocol v1.25 allows configuring the inverter export limit via Modbus holding registers; the firmware automatically enables export limiting at 100% on startup

--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -16,7 +16,7 @@
 // Define the MQTT max packet size here. This only needs to be done for sake of
 // ArduinoIDE compatibility. PlatformIO sets the MQTT_MAX_PACKET_SIZE in platformio.ini
 #ifndef MQTT_MAX_PACKET_SIZE
-#define MQTT_MAX_PACKET_SIZE 2048
+#define MQTT_MAX_PACKET_SIZE 4096
 #endif
 
 // Fronius emulation settings

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -427,6 +427,19 @@ uint8_t Growatt::MapStatusToFronius(uint32_t status) {
   }
 }
 
+const char* Growatt::FroniusStatusToString(uint8_t status) {
+  switch (status) {
+    case 1:
+      return "Waiting";
+    case 7:
+      return "Running";
+    case 16:
+      return "Fault";
+    default:
+      return "Unknown";
+  }
+}
+
 void Growatt::CreateJson(char *Buffer, const char *MacAddress) {
   StaticJsonDocument<2048> doc;
 
@@ -704,7 +717,7 @@ void Growatt::CreateUIJson(char *Buffer) {
   arr.add(320);arr.add("kWh");arr.add(false);
 #endif // SIMULATE_INVERTER
 
-  serializeJson(doc, Buffer, 4096);
+  serializeJson(doc, Buffer, MQTT_MAX_PACKET_SIZE);
 }
 
 void Growatt::CreateFroniusJson(char *Buffer) {
@@ -880,6 +893,7 @@ void Growatt::CreateFroniusJson(char *Buffer) {
   JsonObject devStat = data.createNestedObject("DeviceStatus");
   devStat["ErrorCode"] = 0;
   devStat["StatusCode"] = froniusStatus;
+  devStat["Status"] = FroniusStatusToString(froniusStatus);
   JsonObject pacL1Obj = data.createNestedObject("PAC_L1");
   pacL1Obj["Value"] = pac_l1;
   pacL1Obj["Unit"] = "W";
@@ -1029,6 +1043,7 @@ void Growatt::CreateInverterInfoJson(char *Buffer) {
   inv["PVPower"] = (uint32_t)pdc;
   inv["Show"] = 1;
   inv["StatusCode"] = froniusStatus;
+  inv["Status"] = FroniusStatusToString(froniusStatus);
   inv["UniqueID"] = FRONIUS_SERIAL;
 
   serializeJson(doc, Buffer, MQTT_MAX_PACKET_SIZE);

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -34,6 +34,7 @@ class Growatt {
     void CreateLoggerInfoJson(char *Buffer);
     void CreateActiveDeviceInfoJson(char *Buffer);
     static uint8_t MapStatusToFronius(uint32_t status);
+    static const char* FroniusStatusToString(uint8_t status);
   private:
     eDevice_t _eDevice;
     bool _GotData;

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@ src_dir = SRC/ShineWiFi-ModBus
 monitor_speed = 115200
 upload_speed = 921600
 build_flags =
-    "-D MQTT_MAX_PACKET_SIZE=2048"
+    "-D MQTT_MAX_PACKET_SIZE=4096"
 
 lib_deps =
     ArduinoOTA


### PR DESCRIPTION
## Summary
- enlarge MQTT packet size to 4096 bytes
- use the packet size constant when serializing UI JSON
- show textual Fronius status

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_b_6863721aef44832aa23af6c215c26b59